### PR TITLE
added threshold for IDTypes

### DIFF
--- a/src/valuetypes.ts
+++ b/src/valuetypes.ts
@@ -505,6 +505,7 @@ export async function guessValueType(editors: ValueTypeEditor[], name: string, i
   options = mixin({
     sampleSize: 100,
     thresholds: <any>{
+      idType: 0.7,
       numerical: 0.7,
       categorical: 0.7,
       real: 0.7,


### PR DESCRIPTION
This change should fix the problem that when uploading a categorical columns IDTypes are detected if they contain some values, which are by accident equal to IDTypes

However using a DB dump, which is a small subset of a larger DB it is possible that IDTypes are locally not detected, because the IDType editor would be filtered out due to the new threshold.

Another option would be to give the IDType editor a higher priority ( = less important), such that a categorical column is used instead of the IDType column, if categories are detected