### PR TITLE
prefer categorical columns to idType

### DIFF
--- a/phovea.js
+++ b/phovea.js
@@ -12,7 +12,7 @@ module.exports = function (registry) {
   }, {
     'factory': 'categorical',
     'name': 'Categorical',
-    'priority': 50
+    'priority': 30
   });
 
   registry.push('importer_value_type', 'real', function () {
@@ -44,7 +44,7 @@ module.exports = function (registry) {
   }, {
     'factory': 'idType',
     'name': 'IDType',
-    'priority': 30,
+    'priority': 50,
     'implicit': true
   });
 };


### PR DESCRIPTION
Fixes the problem that when uploading a dataset with categories that are by chance equal to IDTypes that an IDType column is chosen (IDTypes are unique and not repeating)