### PR TITLE
 added matrix type, for Caleydo/lineup#26 

### DIFF
--- a/phovea.js
+++ b/phovea.js
@@ -47,5 +47,13 @@ module.exports = function (registry) {
     'priority': 50,
     'implicit': true
   });
+
+  registry.push('importer_value_type', 'matrix', function () {
+    return System.import('./src/valuetypes');
+  }, {
+    'factory': 'matrix',
+    'name': 'Matrix',
+    'priority': 5
+  });
 };
 

--- a/src/valuetypes.ts
+++ b/src/valuetypes.ts
@@ -344,7 +344,7 @@ export function guessNumerical(def: ITypeDefinition, data: any[], accessor: (row
       maxV = v;
     }
   });
-  anyDef.range = [isNaN(minV) ? 0: minV, isNaN(maxV) ? 100 : maxV];
+  anyDef.range = [isNaN(minV) ? 0 : minV, isNaN(maxV) ? 100 : maxV];
   return def;
 }
 
@@ -474,7 +474,7 @@ export function guessMatrix(def: ITypeDefinition, data: any[], accessor: (row: a
       if(values.length > maxLength) {
         maxLength = values.length;
       }
-    }catch(e) {
+    } catch(e) {
       return; //skip
     }
   });
@@ -498,7 +498,7 @@ function isMatrix(name: string, index: number, data: any[], accessor: (row: any)
       if (typeof v === 'object') {
         numMatrix++;
       }
-    }catch (e) {
+    } catch (e) {
       //parse failed, it is not a matrix
     }
   }
@@ -512,11 +512,13 @@ function parseMatrix(def: ITypeDefinition, data: any[], accessor: (row: any, val
       const v = JSON.parse(accessor(d));
       if(typeof v === 'object') {
         accessor(d, v);
-      }else {
+      } else {
         invalid.push(i);
+        accessor(d, Array(def.dataLength).fill(NaN));
       }
-    }catch(e) {
+    } catch(e) {
       invalid.push(i);
+      accessor(d, Array(def.dataLength).fill(NaN));
     }
   });
   return invalid;

--- a/src/valuetypes.ts
+++ b/src/valuetypes.ts
@@ -412,7 +412,7 @@ export function editMatrix(definition: ITypeDefinition): Promise<ITypeDefinition
   const labels = anyDef.labels || [];
 
   return new Promise((resolve) => {
-    const dialog = createDialog('Edit Numerical Range', 'numerical', () => {
+    const dialog = createDialog('Edit Matrix Properties', 'matrix', () => {
       const rangeMin = parseFloat((<HTMLInputElement>dialog.body.querySelector('input[name="range-min"]')).value);
       const rangeMax = parseFloat((<HTMLInputElement>dialog.body.querySelector('input[name="range-max"]')).value);
       anyDef.range = [rangeMin, rangeMax];

--- a/src/valuetypes.ts
+++ b/src/valuetypes.ts
@@ -399,6 +399,139 @@ export function numerical(): IValueTypeEditor {
   };
 }
 
+/**
+ * edits the given type definition in place with matrix properties
+ * @param definition call by reference argument
+ * @return {Promise<R>|Promise}
+ */
+export function editMatrix(definition: ITypeDefinition): Promise<ITypeDefinition> {
+  const anyDef: any = definition;
+  const range = anyDef.range || [0, 100];
+  const dataLength = anyDef.dataLength || 0;
+  const colorRange = anyDef.colorRange || ['#FFFFFF', '#000000'];
+  const labels = anyDef.labels || [];
+
+  return new Promise((resolve) => {
+    const dialog = createDialog('Edit Numerical Range', 'numerical', () => {
+      const rangeMin = parseFloat((<HTMLInputElement>dialog.body.querySelector('input[name="range-min"]')).value);
+      const rangeMax = parseFloat((<HTMLInputElement>dialog.body.querySelector('input[name="range-max"]')).value);
+      anyDef.range = [rangeMin, rangeMax];
+      anyDef.dataLength = parseInt((<HTMLInputElement>dialog.body.querySelector('input[name="datalength"]')).value, 10);
+      const colorRangeMin = (<HTMLInputElement>dialog.body.querySelector('input[name="colorrange-min"]')).value;
+      const colorRangeMax = (<HTMLInputElement>dialog.body.querySelector('input[name="colorrange-max"]')).value;
+      anyDef.colorRange = [colorRangeMin, colorRangeMax];
+      anyDef.labels = (<HTMLInputElement>dialog.body.querySelector('textarea[name="labels"]')).value.split('\n');
+      dialog.hide();
+      resolve(definition);
+    });
+    dialog.body.innerHTML = `
+        <div class="form-group">
+          <label>Minimum Value</label>
+          <input type="number" class="form-control" name="range-min" step="any" value="${range[0]}">
+        </div>
+        <div class="form-group">
+          <label>Maximum Value</label>
+          <input type="number" class="form-control" name="range-max" step="any" value="${range[1]}">
+        </div>
+        <div class="form-group">
+          <label>Length of Data</label>
+          <input type="number" class="form-control" name="datalength" step="1" min="0" value="${dataLength}">
+        </div>
+        <div class="form-group">
+          <label>Color of Minimum Value</label>
+          <input type="color" class="form-control" name="colorrange-min" value="${colorRange[0]}">
+        </div>
+        <div class="form-group">
+          <label>Color of Maximum Value</label>
+          <input type="color" class="form-control" name="colorrange-max" value="${colorRange[1]}">
+        </div>
+        <div class="form-group">
+          <label>Labels</label>
+          <textarea class="form-control" name="labels">${labels.join('\n')}</textarea>
+        </div>
+    `;
+    dialog.show();
+  });
+}
+
+export function guessMatrix(def: ITypeDefinition, data: any[], accessor: (row: any) => string) {
+  const anyDef: any = def;
+  let minV = NaN;
+  let maxV = NaN;
+  let maxLength = 0;
+  data.forEach((row) => {
+    try {
+      const values = JSON.parse(accessor(row));
+      values.forEach((raw, i) => {
+        const v = parseFloat(raw);
+        if (isNaN(minV) || v < minV) {
+          minV = v;
+        }
+        if (isNaN(maxV) || v > maxV) {
+          maxV = v;
+        }
+      });
+      if(values.length > maxLength) {
+        maxLength = values.length;
+      }
+    }catch(e) {
+      return; //skip
+    }
+  });
+  anyDef.range = [isNaN(minV) ? 0: minV, isNaN(maxV) ? 100 : maxV];
+  anyDef.dataLength = maxLength;
+  anyDef.colorRange = ['#FFFFFF', '#000000'];
+  anyDef.labels = Array.from(Array(maxLength).keys());
+  return def;
+}
+
+function isMatrix(name: string, index: number, data: any[], accessor: (row: any) => string, sampleSize: number) {
+  const testSize = Math.min(data.length, sampleSize);
+  if (testSize <= 0) {
+    return 0;
+  }
+  let numMatrix = 0;
+
+  for (let i = 0; i < testSize; ++i) {
+    try {
+      const v = JSON.parse(accessor(data[i]));
+      if (typeof v === 'object') {
+        numMatrix++;
+      }
+    }catch (e) {
+      //parse failed, it is not a matrix
+    }
+  }
+  return numMatrix / testSize;
+}
+
+function parseMatrix(def: ITypeDefinition, data: any[], accessor: (row: any, value?: any) => string) {
+  const invalid = [];
+  data.forEach((d, i) => {
+    try {
+      const v = JSON.parse(accessor(d));
+      if(typeof v === 'object') {
+        accessor(d, v);
+      }else {
+        invalid.push(i);
+      }
+    }catch(e) {
+      invalid.push(i);
+    }
+  });
+  return invalid;
+}
+
+export function matrix(): IValueTypeEditor {
+  return {
+    isType: isMatrix,
+    parse: parseMatrix,
+    guessOptions: guessMatrix,
+    edit: editMatrix,
+    getOptionsMarkup: singleOption
+  };
+}
+
 export class ValueTypeEditor implements IValueTypeEditor {
   private desc: any;
   private impl: IValueTypeEditor;


### PR DESCRIPTION
Added support for matrix columns in the import dialog.
A column will be automatically recognized as matrix column if the values are JSON encoded arrays.
Example file is attached.
[Example.zip](https://github.com/phovea/phovea_importer/files/1784554/Example.zip)

![grafik](https://user-images.githubusercontent.com/36196885/37027111-bd3087e0-2130-11e8-9095-5476f4ccf2bb.png)

It is also possible to configure the automatically guessed properties of the matrix column.
![grafik](https://user-images.githubusercontent.com/36196885/37027680-54411b58-2132-11e8-8a04-97514e7b51aa.png)

