### PR TITLE
Remove `phovea_d3` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
   "dependencies": {
     "d3": "~3.5.17",
     "papaparse": "~5.3.0",
-    "tdp_core": "github:datavisyn/tdp_core#develop",
-    "phovea_d3": "github:phovea/phovea_d3#develop"
+    "tdp_core": "github:datavisyn/tdp_core#develop"
   }
 }

--- a/phovea_registry.js
+++ b/phovea_registry.js
@@ -12,6 +12,5 @@ import reg from './dist/phovea';
  */
 //other modules
 import 'tdp_core/phovea_registry.js';
-import 'phovea_d3/phovea_registry.js';
 //self
 PluginRegistry.getInstance().register('phovea_importer', reg);


### PR DESCRIPTION
Remove `phovea_d3` dependency since no import in Typescript files found. D3 itself is already a dependency of this package.json.